### PR TITLE
Extend syntax highlighting into inline code blocks

### DIFF
--- a/_scss/pages/_posts.scss
+++ b/_scss/pages/_posts.scss
@@ -61,11 +61,18 @@
     margin: 0 0 $spacing-m;
   }
 
-  ul, 
+  ul,
   ol {
     margin: $spacing-m 0;
     li {
       margin-bottom: $spacing-xs;
+    }
+  }
+
+  p {
+    code {
+      @extend .highlight;
+      padding: 0;
     }
   }
 
@@ -118,21 +125,21 @@
   }
 }
 
-#prev { 
-  left: 40px; 
+#prev {
+  left: 40px;
   @media (max-width: 942px) {
-    float: left; 
+    float: left;
   }
 }
 
-#next { 
-  right: 40px; 
+#next {
+  right: 40px;
   @media (max-width: 942px) {
-    float: right; 
+    float: right;
   }
 }
 
-#prev:active, 
+#prev:active,
 #next:active {
   border-color: $main-color;
 }
@@ -140,7 +147,7 @@
 .nav-title {
   display: none;
   @media (max-width: 942px) {
-    display: inline; 
+    display: inline;
   }
 }
 


### PR DESCRIPTION
Inline `<code>` blocks render differently than larger code blocks. **See below:**

![screen shot 2015-04-01 at 3 02 52 pm](https://cloud.githubusercontent.com/assets/74452/6949066/3ad06dfc-d880-11e4-8ba1-205e6d0527bb.png)

This pull uses Sass' `@extend` directive to use the same treatment provided by Pygments in `_syntax.scss`. **See below:**

![screen shot 2015-04-01 at 3 02 34 pm](https://cloud.githubusercontent.com/assets/74452/6949069/3fd47884-d880-11e4-8c17-32af22f40758.png)
